### PR TITLE
[FIX] base.trplot(): argument length was scaling hom. tf

### DIFF
--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -1770,9 +1770,9 @@ def trplot(T, axes=None, block=True, dims=None, color='blue', frame=None,   # py
 
     # create unit vectors in homogeneous form
     o = T @ np.array([0, 0, 0, 1])
-    x = T @ np.array([1, 0, 0, 1]) * length
-    y = T @ np.array([0, 1, 0, 1]) * length
-    z = T @ np.array([0, 0, 1, 1]) * length
+    x = T @ np.array([length, 0, 0, 1])
+    y = T @ np.array([0, length, 0, 1])
+    z = T @ np.array([0, 0, length, 1])
 
     # draw the axes
 


### PR DESCRIPTION
Dear @petercorke, 

here is mentioned pull request.  
 
HINT: The issue arises whenever the passed pose T in SE3 is not in the origin @ [0;0;0] and the argument length != 1.
The reason is that the length is not just defining the length of the unit-vector in the x,y,z-direction in that pose,
but it is scaling the whole transformation matrix.

x = TF * vec * s   // TF is a 4x4 homogeneous transformation matrix in SE3, vec is a 4x1 homogeneous vector and s is a scalar
// can be rewritten as 
x = TF * s * vec  // now it should be clear  that multiplying a TF with a scalar leads to a non-SE3 element. 

One can also argue that,  vec * s does not result in a homogeneous vector either. 
I hope that was enough explanation :) 


My solution was already mention in the previous PR: https://github.com/petercorke/spatialmath-python/pull/2#issuecomment-769289584 (which can IMHO be deleted)