### PR TITLE
tranimate/tranimate2/animate.trplot/animate.trplot2 support iterable

### DIFF
--- a/spatialmath/base/animate.py
+++ b/spatialmath/base/animate.py
@@ -412,6 +412,7 @@ class Animate2:
         Will setup to plot into an existing or a new Axes3D instance.
 
         """
+        self.trajectory = None
         self.displaylist = []
 
         if axes is None:
@@ -453,6 +454,12 @@ class Animate2:
         :seealso: :func:`run`
 
         """
+        if not isinstance(end, (np.ndarray, np.generic) ) and isinstance(end, Iterable):
+            if len(end) == 1:
+                end = end[0]
+            elif len(end) >= 2:
+                self.trajectory = end
+
         # stash the final value
         if base.isrot2(end):
             self.end = base.r2t(end)
@@ -496,7 +503,11 @@ class Animate2:
         """
 
         def update(frame, a):
-            T = base.trinterp2(start=self.start, end=self.end, s=frame / nframes)
+            # if contains trajectory:
+            if self.trajectory is not None:
+                T = self.trajectory[frame]
+            else:
+                T = base.trinterp2(start=self.start, end=self.end, s=frame / nframes)
             a._draw(T)
             if frame == nframes - 1:
                 a.done = True
@@ -507,6 +518,8 @@ class Animate2:
             repeat = False
 
         self.done = False
+        if self.trajectory is not None:
+            nframes = len(self.trajectory)
         ani = animation.FuncAnimation(fig=plt.gcf(), func=update, frames=range(0, nframes), fargs=(self,), blit=False, interval=interval, repeat=repeat)
 
         if movie is None:

--- a/spatialmath/base/animate.py
+++ b/spatialmath/base/animate.py
@@ -106,13 +106,11 @@ class Animate:
         :seealso: :func:`run`
 
         """
-        if isinstance(end, Iterable):
+        if not isinstance(end, (np.ndarray, np.generic) ) and isinstance(end, Iterable):
             if len(end) == 1:
                 end = end[0]
             elif len(end) >= 2:
                 self.trajectory = end
-                start = self.trajectory[0]
-                end = self.trajectory[-1]
 
         # stash the final value
         if base.isrot(end):


### PR DESCRIPTION
Refer to issue https://github.com/petercorke/spatialmath-python/issues/4

### tranimate
use case 1: quaterion interpolation
```
import matplotlib
matplotlib.use('TkAgg')
from spatialmath import *
from spatialmath.base import *
from roboticstoolbox.tools.trajectory import lspb, tpoly, ctraj, jtraj
import math

r1 = SE3.Rx(math.pi/2)
r2 = SE3.Rz(-math.pi/2)
q1 = UnitQuaternion(r1)
q2 = UnitQuaternion(r2)
traj = []
steps = 50
for i in range(0, steps):
    traj.append(q1.interp(1.0*i/steps, q2).SE3().A)
tranimate(traj, dims = [-1,1], repeat=True)
```

use case 2:
```
import matplotlib
matplotlib.use('TkAgg')
from spatialmath import *
from spatialmath.base import *
from roboticstoolbox.tools.trajectory import lspb, tpoly, ctraj, jtraj

T0 = SE3(0, 0, 0)
T3 = SE3(3, 3, 3)

traj = []
steps = 50
for i in range(steps):
    traj.append(ctraj(T0, T3, 1.0*i/steps).A)

tranimate(traj, dims = [0,5], repeat=True)
```


### tranimate2
```
import matplotlib
matplotlib.use('TkAgg')
from spatialmath import *
from spatialmath.base import *

traj = []
steps = 50
for i in range(steps):
    traj.append(SE2(1.0*i/steps, 1.0*i/steps).A)
tranimate2(traj, dims = [0,5], repeat=True)
```