### PR TITLE
Fixing issue with SE3.Rt ignoring check=False

### DIFF
--- a/spatialmath/pose3d.py
+++ b/spatialmath/pose3d.py
@@ -1567,7 +1567,7 @@ class SE3(SO3):
         else:
             raise ValueError('expecting SO3 or rotation matrix')
 
-        return cls(base.rt2tr(R, t))
+        return cls(base.rt2tr(R, t, check=check), check=check)
 
     def angdist(self, other, metric=6):
         r"""


### PR DESCRIPTION
Fixing an issue where passing check=False to SE3.Rt still results in invalid constructor errors for certain rotation matrices.