### PR TITLE
length arg error of SE2.plot() function (trplot2)

### DIFF
--- a/spatialmath/base/transforms2d.py
+++ b/spatialmath/base/transforms2d.py
@@ -904,7 +904,7 @@ def trplot2(
         ax.autoscale(enable=True, axis="both")
 
     # create unit vectors in homogeneous form
-    o = T @ np.array([0, 0, 1])
+    o = T @ np.array([0, 0, 1]) * length
     x = T @ np.array([1, 0, 1]) * length
     y = T @ np.array([0, 1, 1]) * length
 


### PR DESCRIPTION
I found an error in trplot2()
The code below reproduces the error
```python
a = SE2.Rand()
a.plot(length=0.1)
```