### PR TITLE
Fix division by scalar for `Twist2` classes

### DIFF
--- a/spatialmath/twist.py
+++ b/spatialmath/twist.py
@@ -282,7 +282,7 @@ class BaseTwist(BasePoseList):
 
     def __truediv__(left, right):  # lgtm[py/not-named-self] pylint: disable=no-self-argument
         if base.isscalar(right):
-            return Twist3(left.S / right)
+            return type(left)(left.S / right)
         else:
             raise ValueError('Twist /, incorrect right operand')
 


### PR DESCRIPTION
Division by a scalar works for `Twist3` classes, but throws this error for `Twist2` classes:

```
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-6-05a7052c8927> in <module>
----> 1 t / 1                                                                                        
                                                                                                     
~/qut/repos/spatialmath-python/spatialmath/twist.py in __truediv__(left, right)
    283     def __truediv__(left, right):  # lgtm[py/not-named-self] pylint: disable=no-self-argument
    284         if base.isscalar(right):                                                             
--> 285             return Twist3(left.S / right)                                                    
    286         else:                             
    287             raise ValueError('Twist /, incorrect right operand')            
                                                  
~/qut/repos/spatialmath-python/spatialmath/twist.py in __init__(self, arg, w, check)
    328         if w is None:                                                                        
    329             # zero or one arguments passed 
--> 330             if super().arghandler(arg, check=check):
    331                 return
    332             elif isinstance(arg, SE3):                                                       
                         
~/qut/repos/spatialmath-python/spatialmath/baseposelist.py in arghandler(self, arg, convertfrom, check)
    182         elif isinstance(arg, np.ndarray):
    183             # it's a numpy array                                                             
--> 184             x = self._import(arg, check=check)
    185             if x is not None:  
    186                 self.data = [x]
                                                                                                     
~/qut/repos/spatialmath-python/spatialmath/twist.py in _import(self, value, check)
    357         elif base.ishom(value, check=check):                     
    358                 return base.trlog(value, twist=True, check=False)
--> 359         raise TypeError('bad type passed')
    360                  
    361     @staticmethod                         
                                                  
TypeError: bad type passed
```

The error is caused by `__truediv__()` in the `BaseTwist` class returning a `Twist3()` instance when divided by a scalar, rather than a type corresponding to the `left` param. 

This PR fixes this.