### PR TITLE
Fix __ne__ error, and add opinionated change to __eq__, in `BasePoseMatrix`

### DIFF
--- a/spatialmath/baseposematrix.py
+++ b/spatialmath/baseposematrix.py
@@ -1577,8 +1577,8 @@ class BasePoseMatrix(BasePoseList):
         :return: list of matrices
         :rtype: list
 
-        Peform a binary operation on a pair of operands.  If either operand
-        contains a sequence the results is a sequence accordinging to this
+        Perform a binary operation on a pair of operands.  If either operand
+        contains a sequence the results is a sequence according to this
         truth table.
 
         =========   ==========   ====  ================================

--- a/spatialmath/baseposematrix.py
+++ b/spatialmath/baseposematrix.py
@@ -1559,7 +1559,8 @@ class BasePoseMatrix(BasePoseList):
         =========   ==========   ====  ================================
 
         """
-        return [not x for x in left == right]
+        eq = left == right
+        return (not eq if isinstance(eq, bool) else [not x for x in eq])
 
     def _op2(
         left, right, op

--- a/spatialmath/baseposematrix.py
+++ b/spatialmath/baseposematrix.py
@@ -1531,8 +1531,8 @@ class BasePoseMatrix(BasePoseList):
         =========   ==========   ====  ================================
 
         """
-        assert type(left) == type(right), "operands to == are of different types"
-        return left._op2(right, lambda x, y: np.allclose(x, y))
+        return (left._op2(right, lambda x, y: np.allclose(x, y))
+                if type(left) == type(right) else False)
 
     def __ne__(left, right):  # lgtm[py/not-named-self] pylint: disable=no-self-argument
         """


### PR DESCRIPTION
This PR has two parts.

**1. Error in `!=` comparisons**
Comparing two of most things using the `!=` operator currently fails with the following error unless you make them lists:
```
In [6]: SO3() != SO3()   
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-6-16fbcbbd9d14> in <module>
----> 1 SO3() != SO3()

~/qut/repos/spatialmath-python/spatialmath/baseposematrix.py in __ne__(left, right)
   1560 
   1561         """
-> 1562         return [not x for x in left == right]
   1563 
   1564     def _op2(

TypeError: 'bool' object is not iterable
```
This is due to `__ne__` assuming comparison results are a list. Commit 13d6ee1 addresses this.

**2. An _opinionated_ change to `==` comparisons**
Currently a runtime assertion error is thrown if two things are compared of different types. 

I know I would find simply receive a `False` return easier to work with in code, as two different types definitely aren't equal. But that's just one opinion, and I can see how the way it currently is also makes sense.

Happy for this part of the PR to be reverted if desired:
```
git revert 7297788
```

