### PR TITLE
Fixes import errors in Python 3.6 #52

### DIFF
--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -21,7 +21,7 @@ import scipy as sp
 from collections.abc import Iterable
 
 from spatialmath import base as smb
-import spatialmath.base.symbolic as sym
+from spatialmath.base import symbolic as sym
 
 _eps = np.finfo(np.float64).eps
 


### PR DESCRIPTION
Hi @petercorke,

Many thanks for developing this wonderful package!
As mentioned in https://github.com/petercorke/spatialmath-python/issues/52#issuecomment-1135414149, I found that the following import behavior does not work in Python 3.6 due to circular imports (but works in 3.7+, which is mentioned in https://github.com/python/cpython/issues/74210):

https://github.com/petercorke/spatialmath-python/blob/da5aa910617869715da9e661da475ba83b28c59f/spatialmath/base/transforms3d.py#L24

Therefore, I manage to fix this issue by simply modifying the statement to let the project work fine in Python 3.6 as well.
Please let me know if you have any questions or comments for this pull request. Thank you!

Best,
Yu-Kai