### PR TITLE
Fix axis textcolor in transform3d

### DIFF
--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -2931,15 +2931,6 @@ def trplot(
 
     # label the frame
     if frame:
-        if textcolor is None:
-            textcolor = color[0]
-        else:
-            textcolor = "blue"
-        if origincolor is None:
-            origincolor = color[0]
-        else:
-            origincolor = "black"
-
         o1 = T @ np.array(np.r_[flo, 1])
         ax.text(
             o1[0],


### PR DESCRIPTION
This PR fixes the issue of not setting the axis label textcolor appropriately.
```bash
trplot(T,  frame='W', color="green", length=3, dims=[-5,5], axes=ax1)
```
Will only change the color of axes, but not their labels. The labels stay blue.


With this PR, the axes label will take the color of `color` argument