### PR TITLE
Fix textcolor / origincolor in 3d plot: 

### DIFF
--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -2933,15 +2933,6 @@ def trplot(
 
     # label the frame
     if frame:
-        if textcolor is None:
-            textcolor = color[0]
-        else:
-            textcolor = "blue"
-        if origincolor is None:
-            origincolor = color[0]
-        else:
-            origincolor = "black"
-
         o1 = T @ np.array(np.r_[flo, 1])
         ax.text(
             o1[0],


### PR DESCRIPTION
Hi,
Attributes 'textcolor' and 'origincolor' aren't applied for 'frame' case.
`
SO3().plot(frame="LABEL",color="green")
`
![image](https://user-images.githubusercontent.com/8236593/221411827-f28349f7-a041-487d-9570-e19be90cb057.png)

Since value of textcolor and origincolor are already computed just before handling 'frame' case, there is no need to compute again.
 