### PR TITLE
Fix color of arrow style

### DIFF
--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -3220,7 +3220,7 @@ if _matplotlib_exists:
                 arrow_length_ratio=wtl,
                 linewidth=width,
                 facecolor=color[0],
-                edgecolor=color[1],
+                edgecolor=color[0],
             )
             ax.quiver(
                 o[0],


### PR DESCRIPTION
When plotting with arrow style but assigning different colors to each axis, then there is a color mismatch.
```
X = SE3.Rand()
X.plot(color=["r","g","b"], textcolor="k")
```
![image](https://user-images.githubusercontent.com/7974580/226556812-eefb5cdf-9024-4795-b4b1-6b27bd969f1e.png)
One would expect color-wise:
`X.plot(color=["r","g","b"], textcolor="k", style="line")`
![image](https://user-images.githubusercontent.com/7974580/226557232-2e22e199-2c44-49f0-a87a-1b0df82b2735.png)
Investigation of the code revealed that there was an indexing error when plotting the x-axis with quiver. 
