### PR TITLE
Fix handling of color for labels

### DIFF
--- a/spatialmath/base/transforms3d.py
+++ b/spatialmath/base/transforms3d.py
@@ -3281,22 +3281,11 @@ if _matplotlib_exists:
         if textcolor == "":
             textcolor = color[0]
 
-        if origincolor != "":
+        if origincolor == "":
             origincolor = color[0]
-        else:
-            origincolor = "black"
 
         # label the frame
         if frame != "":
-            if textcolor is None:
-                textcolor = color[0]
-            else:
-                textcolor = "blue"
-            if origincolor is None:
-                origincolor = color[0]
-            else:
-                origincolor = "black"
-
             o1 = T @ np.array(np.r_[flo, 1])
             ax.text(
                 o1[0],


### PR DESCRIPTION
According to the description, the color for origin and axis labels should default to `color`. However,
- if origin color is defined without a frame label, then origin color is ignored
- if a frame label is given, then the color is set to blue for origin and axis labels
```
X = SE3.Rand()
X.plot(color=["r","g","b"], textcolor="k", origincolor="k", style="line")
```
![image](https://user-images.githubusercontent.com/7974580/226567844-327ce26d-16e9-4884-8434-2a147f408692.png)
`X.plot(frame="A", color=["r","g","b"], textcolor="k", origincolor="k", style="line")`
![image](https://user-images.githubusercontent.com/7974580/226568048-5a374a70-f1fc-4b15-93f4-723f819fd197.png)
There was some "code duplication".
